### PR TITLE
Update Kubernetes configurations: remove key vault secrets provider a…

### DIFF
--- a/certificate.yaml
+++ b/certificate.yaml
@@ -10,4 +10,4 @@ spec:
     kind: ClusterIssuer
   commonName: test.architect4hire.com
   dnsNames:
-    - "test.architect4hire.com"
+    - test.architect4hire.com


### PR DESCRIPTION
This pull request includes changes to improve DNS formatting in a certificate configuration file and updates to Azure Kubernetes Service (AKS) resources in Terraform. The most significant changes involve removing the key vault secrets provider from the AKS cluster configuration and adding network security group (NSG) resources to enhance security.

### DNS Formatting:
* [`certificate.yaml`](diffhunk://#diff-1f09b16503352e865e9109f238de109ac845d111a5fb20335e20aa0341e359c9L13-R13): Simplified DNS name formatting by removing quotation marks around `test.architect4hire.com`.

### AKS Resource Updates:
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL171-L175): Removed the `key_vault_secrets_provider` block from the AKS cluster configuration, which included secret rotation settings.
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR208-R244): Added `azurerm_subnet_network_security_group_association` and `azurerm_network_security_group` resources to associate the AKS subnet with a network security group and define security rules for inbound and outbound traffic.…nd add network security group for AKS